### PR TITLE
feat(models): add SuggestedTopics feed item model

### DIFF
--- a/lib/src/models/feed_decorators/suggested_topics.dart
+++ b/lib/src/models/feed_decorators/suggested_topics.dart
@@ -1,0 +1,62 @@
+import 'package:core/src/models/core/feed_item.dart';
+import 'package:core/src/models/entities/topic.dart';
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:meta/meta.dart';
+
+part 'suggested_topics.g.dart';
+
+/// {@template suggested_topics}
+/// Represents a feed item that suggests a list of topics to the user.
+/// {@endtemplate}
+@immutable
+@JsonSerializable(
+  explicitToJson: true,
+  includeIfNull: true,
+  checked: true,
+  genericArgumentFactories: true,
+)
+class SuggestedTopics extends FeedItem {
+  /// {@macro suggested_topics}
+  const SuggestedTopics({
+    required this.id,
+    required this.title,
+    required this.topics,
+  }) : super(type: 'suggested_topics');
+
+  /// Factory method to create a [SuggestedTopics] instance from a JSON map.
+  factory SuggestedTopics.fromJson(Map<String, dynamic> json) =>
+      _$SuggestedTopicsFromJson(json);
+
+  /// Unique identifier for the suggested topics item.
+  final String id;
+
+  /// The title for the suggestion card (e.g., "Topics you might like").
+  final String title;
+
+  /// The list of suggested topics.
+  final List<Topic> topics;
+
+  @override
+  Map<String, dynamic> toJson() {
+    final json = _$SuggestedTopicsToJson(this);
+    json['type'] = type;
+    return json;
+  }
+
+  @override
+  List<Object?> get props => [id, title, topics, type];
+
+  /// Creates a new [SuggestedTopics] with updated properties.
+  SuggestedTopics copyWith({
+    String? id,
+    String? title,
+    List<Topic>? topics,
+  }) {
+    return SuggestedTopics(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      topics: topics ?? this.topics,
+    );
+  }
+}


### PR DESCRIPTION
## Status

**READY**

## Description

This PR introduces two new feed item types, `SuggestedTopics` and `SuggestedSources`, to provide a richer user experience for content suggestions. The previous approach of using a generic `FeedAction` was limiting, as it could not carry the necessary data for a list of suggested items.

This change implements the following:
-   Adds `SuggestedTopics` and `SuggestedSources` models, both extending `FeedItem`.
-   Updates the core `FeedItem.fromJson` factory to handle the new types.
-   Removes the now-obsolete `followTopics` and `followSources` from the `FeedActionType` enum, as their functionality is now handled by these richer models.

This refactor improves the system's architecture by using specific, strongly-typed models for distinct content types, making the feed more robust and easier to extend.

Closes #28 

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧹 Code refactor
